### PR TITLE
.vscodeディレクトリの作成・リポジトリrenameにおける修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cSpell.words": ["Errorda", "nachi", "vercel", "notionhq"],
+  "window.title": "${dirty}${activeEditorShort}${separator}errorda2_flag_checker"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "errorda2_backend",
+  "name": "errorda2_flag_checker",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## やったこと

- .vscodeディレクトリの作成
  - スペルチェック対象外ワードの設定
  - タイトル名を設定
- package.jsonの名前を変更
 　　
  <br>

## なぜやるのか・背景

- 意図しない警告マークを発生させないため・どのプロジェクトを開いているかの視認性向上の為
- リポジトリ名を変更したため
  <br>

## 動作確認

- OS:mac
- vscode上で反映されていることを確認
  <br>

## その他

- [Errorda2](https://github.com/nachi739/Errorda2)でのサブモジュールの更新処理を別途確認